### PR TITLE
docs(readme): fix inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Checkout CLI's [config documentation](https://github.com/scaleway/scaleway-cli/b
 - name: Use CLI
   uses: scaleway/action-scw@v0
   with:
-    save_config: true
-    export_config: true
+    save-config: true
+    export-config: true
     version: v2.24.0
     access-key: ${{ secrets.SCW_ACCESS_KEY }}
     secret-key: ${{ secrets.SCW_SECRET_KEY }}


### PR DESCRIPTION
Fix some wrong inputs in documentation (README). 

`Warning: Unexpected input(s) 'save_config', 'export_config', valid inputs are ['version', 'args', 'save-config', 'export-config', 'access-key', 'secret-key', 'default-project-id', 'default-organization-id']`