### PR TITLE
feat: add compatibility for multiple os and arch

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -30837,6 +30837,8 @@ var io = __nccwpck_require__(2826);
 var tool_cache = __nccwpck_require__(5561);
 // EXTERNAL MODULE: external "fs"
 var external_fs_ = __nccwpck_require__(7147);
+// EXTERNAL MODULE: external "os"
+var external_os_ = __nccwpck_require__(2037);
 // EXTERNAL MODULE: ./node_modules/.pnpm/@actions+http-client@2.2.1/node_modules/@actions/http-client/lib/index.js
 var lib = __nccwpck_require__(6372);
 ;// CONCATENATED MODULE: ./lib/version.js
@@ -30871,13 +30873,36 @@ const getLatest = async () => {
 
 
 
+
 const TOOL_NAME = 'scw';
+const PLATFORM_MAP = {
+    darwin: 'darwin',
+    freebsd: 'freebsd',
+    win32: 'windows',
+};
+const ARCH_MAP = {
+    arm64: 'arm64',
+    i386: '386',
+};
 const downloadURL = (targetVersion) => {
     let version = targetVersion;
+    let platform = 'linux';
+    let arch = 'amd64';
+    if (external_os_.platform() in PLATFORM_MAP) {
+        platform = PLATFORM_MAP[external_os_.platform()];
+    }
+    if (external_os_.machine() in ARCH_MAP) {
+        if (platform === 'windows') {
+            arch = `${ARCH_MAP[external_os_.machine()]}.exe`;
+        }
+        else {
+            arch = ARCH_MAP[external_os_.machine()];
+        }
+    }
     if (version.startsWith('v')) {
         version = version.slice(1);
     }
-    return `https://github.com/scaleway/scaleway-cli/releases/download/v${version}/scaleway-cli_${version}_linux_amd64`;
+    return `https://github.com/scaleway/scaleway-cli/releases/download/v${version}/scaleway-cli_${version}_${platform}_${arch}`;
 };
 const isInPath = (toolPath) => {
     const envPath = process.env.PATH;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,19 +2,43 @@ import * as core from '@actions/core'
 import * as io from '@actions/io'
 import * as tc from '@actions/tool-cache'
 import { promises as fs } from 'fs'
+import os from 'os'
 import type { Args } from './input.js'
 import { VERSION_LATEST, getLatest } from './version.js'
 
 const TOOL_NAME = 'scw'
+const PLATFORM_MAP = {
+  darwin: 'darwin',
+  freebsd: 'freebsd',
+  win32: 'windows',
+}
+const ARCH_MAP = {
+  arm64: 'arm64',
+  i386: '386',
+}
 
 const downloadURL = (targetVersion: string): string => {
   let version = targetVersion
+  let platform = 'linux'
+  let arch = 'amd64'
+
+  if (os.platform() in PLATFORM_MAP) {
+    platform = PLATFORM_MAP[os.platform() as keyof typeof PLATFORM_MAP]
+  }
+
+  if (os.machine() in ARCH_MAP) {
+    if (platform === 'windows') {
+      arch = `${ARCH_MAP[os.machine() as keyof typeof ARCH_MAP]}.exe`
+    } else {
+      arch = ARCH_MAP[os.machine() as keyof typeof ARCH_MAP]
+    }
+  }
 
   if (version.startsWith('v')) {
     version = version.slice(1)
   }
 
-  return `https://github.com/scaleway/scaleway-cli/releases/download/v${version}/scaleway-cli_${version}_linux_amd64`
+  return `https://github.com/scaleway/scaleway-cli/releases/download/v${version}/scaleway-cli_${version}_${platform}_${arch}`
 }
 
 const isInPath = (toolPath: string): boolean => {


### PR DESCRIPTION
Download the appropriate CLI binary according to the detected `os` and `arch`, as well as the [binaries generated in releases](https://github.com/scaleway/scaleway-cli/releases/tag/v2.30.0). 

Another option would be to use the docker [scaleway/cli image](https://hub.docker.com/r/scaleway/cli), but there is only one for `linux/amd64`, so you have to publish images for other platforms/arch.