### PR TITLE
fix: detect linux arm64 (and other uname arch values)

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -34770,9 +34770,16 @@ const PLATFORM_MAP = {
     freebsd: 'freebsd',
     win32: 'windows',
 };
+// Keyed by os.machine() (the `uname -m` value), which differs per platform:
+// Linux reports x86_64 / aarch64 / i686, while macOS reports x86_64 / arm64.
+// Values match Scaleway's release asset suffixes (linux_amd64, linux_arm64, ...).
 const ARCH_MAP = {
+    x86_64: 'amd64',
+    amd64: 'amd64',
+    aarch64: 'arm64',
     arm64: 'arm64',
     i386: '386',
+    i686: '386',
 };
 const downloadURL = (targetVersion) => {
     let version = targetVersion;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,9 +12,16 @@ const PLATFORM_MAP = {
   freebsd: 'freebsd',
   win32: 'windows',
 }
+// Keyed by os.machine() (the `uname -m` value), which differs per platform:
+// Linux reports x86_64 / aarch64 / i686, while macOS reports x86_64 / arm64.
+// Values match Scaleway's release asset suffixes (linux_amd64, linux_arm64, ...).
 const ARCH_MAP = {
+  x86_64: 'amd64',
+  amd64: 'amd64',
+  aarch64: 'arm64',
   arm64: 'arm64',
   i386: '386',
+  i686: '386',
 }
 
 const downloadURL = (targetVersion: string): string => {


### PR DESCRIPTION
## Problem

`downloadURL()` picks the release asset suffix from `os.machine()`, but `ARCH_MAP` only contains `arm64` and `i386`:

```js
const ARCH_MAP = {
  arm64: 'arm64',
  i386: '386',
}
```

`os.machine()` returns the `uname -m` value, and that differs by platform:

| Platform | `os.machine()` | in current map? |
|---|---|---|
| Linux x86-64 | `x86_64` | ❌ → falls back to `amd64` (happens to be correct) |
| **Linux arm64** | **`aarch64`** | ❌ → **falls back to `amd64` (wrong)** |
| macOS arm64 | `arm64` | ✅ |

So on a **Linux arm64** runner the action downloads the **x86-64** binary. On an arm64 host that binary can't be executed — the kernel returns `ENOEXEC`, libuv's `spawn` falls back to `/bin/sh`, and the CLI invocation dies with a misleading error such as:

```
/home/runner/_work/_tool/scw/2.56.1/arm64/scw: 4: Syntax error: Unterminated quoted string
CLIError: failed to run command, code: 2
    at saveConfig (...)
```

This reproduces on GitHub-hosted/self-hosted Linux arm64 runners. As a side effect, the Windows `.exe` suffix is also only applied when `os.machine()` is already in the map, so Windows x64 (`x86_64`) would miss it too.

## Fix

Extend `ARCH_MAP` to cover the Linux `uname -m` values alongside the existing macOS ones, with values matching Scaleway's release asset suffixes (`linux_amd64`, `linux_arm64`, `linux_386`):

```js
const ARCH_MAP = {
  x86_64: 'amd64',
  amd64: 'amd64',
  aarch64: 'arm64',
  arm64: 'arm64',
  i386: '386',
  i686: '386',
}
```

This selects the correct asset on Linux (`x86_64` / `aarch64` / `i686`), macOS (`x86_64` / `arm64`) and Windows. amd64 behavior is unchanged.

`dist/` was regenerated with `pnpm install && pnpm build && pnpm package` (pnpm 8.15.6, ncc 0.38.1, per the lockfile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)